### PR TITLE
- allow to not provide sep for seconds neither seconds

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -52,8 +52,8 @@ function moduloTwoPI(value, zCentered = false) {
 
 // Degree/radian conversion and sexagesimal display
 
-const SEXA_FORMAT = new RegExp("-?\\d+(\\D+)\\d+(\\D+)\\d+(\\D*)");
-const SEXA_VALUE = new RegExp("(-?\\d+)\\D+(\\d+)\\D+(\\d+)");
+const SEXA_FORMAT = new RegExp("-?\\d+(\\D+)\\d+(\\D+)\\d*(\\D*)");
+const SEXA_VALUE = new RegExp("(-?\\d+)\\D+(\\d+)\\D*(\\d*)");
 
 /**
  * Extracts the sexagesimal format from a sexagesimal value


### PR DESCRIPTION
Small change to allow sexagesimal w/o seonds neither separator after seconds

allowed:

33d45 == 33d45'00"

